### PR TITLE
Improve load runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+## 0.2.1 - 11. April 2022
+
+- Delete broken test
+- Optimize storing of errata into SQLite database
+    - Only 1 store instead of 2
+- Optimize lookup of CVE Audit of the systems in the SUSE Manager
+    - Lazy cache with BTree, only query API if the CVE-ID is not yet asked for in one run, othewise take stored result
+
+
+## 0.2.0 - 07. April 2022
+
+First officially (open) published version.
+Minimal GUI with SQL-Lite Database as a backed and async loading of SUSE Manager API.
+
+## 0.1.0
+Version not public available. Prototype with very basic GUI and limited lists.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suma-cve-audit-tool"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/persistence/rdbms.rs
+++ b/src/persistence/rdbms.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, Result, params};
+use rusqlite::{Connection, Result, params, OpenFlags};
 
 
 // Constants
@@ -37,7 +37,7 @@ fn open_db() -> Connection {
     let mut path = dir.join("db");
     path.push(DB_NAME);
 
-    Connection::open(path.to_str().unwrap()).unwrap()
+    Connection::open_with_flags(path.to_str().unwrap(), OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_FULL_MUTEX).unwrap()
 }
 
 // current path
@@ -98,15 +98,14 @@ pub fn setup() -> Result<()> {
 
 pub fn store_errata(i_errata: &cve_audit_types::Errata) -> Result<()> {
     let conn = open_db();
-    let stmt = r#"INSERT INTO errata VALUES (?1, julianday(?2), julianday(?3), ?4, ?5, ?6) ON CONFLICT DO NOTHING"#;
+    let mut stmt = conn.prepare_cached(r#"INSERT INTO errata VALUES (?1, julianday(?2), julianday(?3), ?4, ?5, ?6) ON CONFLICT DO NOTHING"#)?;
 
-    match conn.execute(&stmt, 
-            params![i_errata.id, 
-                    i_errata.date, 
-                    i_errata.update_date, 
-                    i_errata.advisory_type, 
-                    i_errata.advisory_name, 
-                    i_errata.advisory_synopsis],
+    match stmt.execute(params![i_errata.id, 
+                        i_errata.date, 
+                        i_errata.update_date, 
+                        i_errata.advisory_type, 
+                        i_errata.advisory_name, 
+                        i_errata.advisory_synopsis]
             )
     {
         Ok(inserted) => log::info!("Rows inserted {}", inserted),
@@ -118,17 +117,17 @@ pub fn store_errata(i_errata: &cve_audit_types::Errata) -> Result<()> {
 
 pub fn store_cve(i_errata_ext: &cve_audit_types::ErrataExtended) -> Result<()> {
     let conn = open_db();
-    let stmt = r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#;
-    let stmt_rel = r#"INSERT INTO errata_cve (cve_id, errata_id) VALUES (?1, ?2) ON CONFLICT DO NOTHING"#;
+    let mut stmt = conn.prepare_cached(r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#)?;
+    let mut stmt_rel = conn.prepare_cached(r#"INSERT INTO errata_cve (cve_id, errata_id) VALUES (?1, ?2) ON CONFLICT DO NOTHING"#)?;
 
     for c in i_errata_ext.cves.iter() {
 
-        match conn.execute(stmt, params![c]) {
+        match stmt.execute(params![c]) {
             Ok(inserted) => log::info!("store_cve.cve: rows inserted {}", inserted),
             Err(err)     => log::error!("store_cve insert failed: {}", err),
         };
         
-        match conn.execute(stmt_rel, params![c, i_errata_ext.id]) {
+        match stmt_rel.execute(params![c, i_errata_ext.id]) {
             Ok(inserted) => log::info!("store_cve.errata_cve: rows inserted {}", inserted),
             Err(err)     => log::error!("errata_cve insert failed: {}", err),
         };
@@ -140,15 +139,15 @@ pub fn store_cve(i_errata_ext: &cve_audit_types::ErrataExtended) -> Result<()> {
 pub fn store_cve_affsystem(i_cve: &str, i_num_asys: i32) -> Result<()> {
 
     let conn = open_db();
-    let stmt_cve = r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#;
-    let stmt = r#"INSERT INTO cve_systems (cve_id, affected_systems_cnt, last_checked_date) VALUES (?1, ?2, julianday('now'));"#;
+    let mut stmt_cve = conn.prepare_cached(r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#)?;
+    let mut stmt = conn.prepare_cached(r#"INSERT INTO cve_systems (cve_id, affected_systems_cnt, last_checked_date) VALUES (?1, ?2, julianday('now'));"#)?;
 
-    match conn.execute(stmt_cve, params![i_cve]) {
+    match stmt_cve.execute(params![i_cve]) {
         Ok(inserted) => log::info!("store_cve_affsystem: rows inserted {}", inserted),
         Err(err)     => log::error!("store_cve_affsystem insert failed: {}", err),
     }; 
 
-    match conn.execute(stmt, params![i_cve, i_num_asys]) {
+    match stmt.execute(params![i_cve, i_num_asys]) {
         Ok(inserted) => log::info!("store_cve_affsystem: rows inserted {}", inserted),
         Err(err)     => log::error!("store_cve_affsystem insert failed: {}", err),
     }; 

--- a/src/persistence/rdbms.rs
+++ b/src/persistence/rdbms.rs
@@ -115,14 +115,29 @@ pub fn store_errata(i_errata: &cve_audit_types::Errata) -> Result<()> {
     Ok(())
 }
 
-pub fn store_cve(i_errata_ext: &cve_audit_types::ErrataExtended) -> Result<()> {
+pub fn store_ee(i_errata_ext: &cve_audit_types::ErrataExtended) -> Result<()> {
     let conn = open_db();
-    let mut stmt = conn.prepare_cached(r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#)?;
+    let stmt_errata = r#"INSERT INTO errata VALUES (?1, julianday(?2), julianday(?3), ?4, ?5, ?6) ON CONFLICT DO NOTHING"#;
+    let mut stmt_cve = conn.prepare_cached(r#"INSERT INTO cve (id) VALUES (?) ON CONFLICT (id) DO NOTHING"#)?;
     let mut stmt_rel = conn.prepare_cached(r#"INSERT INTO errata_cve (cve_id, errata_id) VALUES (?1, ?2) ON CONFLICT DO NOTHING"#)?;
+
+    // first insert the errata
+    match conn.execute(stmt_errata, 
+        params![i_errata_ext.id, 
+            i_errata_ext.date, 
+            i_errata_ext.update_date, 
+            i_errata_ext.advisory_type, 
+            i_errata_ext.advisory_name, 
+            i_errata_ext.advisory_synopsis],)
+    {
+        Ok(inserted) => log::info!("Rows inserted {}", inserted),
+        Err(err)     => log::error!("insert failed: {}", err),
+    };
+
 
     for c in i_errata_ext.cves.iter() {
 
-        match stmt.execute(params![c]) {
+        match stmt_cve.execute(params![c]) {
             Ok(inserted) => log::info!("store_cve.cve: rows inserted {}", inserted),
             Err(err)     => log::error!("store_cve insert failed: {}", err),
         };

--- a/src/suma/sumaclient.rs
+++ b/src/suma/sumaclient.rs
@@ -86,6 +86,7 @@ fn fetch_errata(suma_clt: &SumaClient) {
     let since = iso8601::datetime(Utc::now().checked_sub_signed(Duration::days(14)).unwrap().to_rfc3339().as_str()).unwrap();
 
     let mut suse_errata: HashMap<String, Errata> = HashMap::new();
+    let mut cve_systems: HashMap<String, i32> = HashMap::new();
 
     for vc in vendor_channel_request {
         let channel_errata = Request::new("channel.software.listErrata").arg(suma_clt.session.as_str()).arg(vc["label"].as_str().unwrap()).arg(since).call_url(suma_clt.rpcurl.as_str()).unwrap();
@@ -106,35 +107,51 @@ fn fetch_errata(suma_clt: &SumaClient) {
     // find the CVEs
     for (en, er) in suse_errata.iter() {
         // first store the errata
-        match rdbms::store_errata(er) {
-            Ok(()) => log::info!("Errata stored"),
-            Err(e) => log::error!("sumaclient fetch_errata error occured {}", e),
-        };
+        // match rdbms::store_errata(er) {
+        //     Ok(()) => log::info!("Errata stored"),
+        //     Err(e) => log::error!("sumaclient fetch_errata error occured {}", e),
+        // };
         let cves_resp = Request::new("errata.listCves").arg(suma_clt.session.as_str()).arg(en.as_str()).call_url(suma_clt.rpcurl.as_str()).unwrap();
 
         // convert errata to ErrataExtended
         let mut ee = ErrataExtended::from(er.clone());
-        let sel_val = xmlrpc::Value::Array(vec![xmlrpc::Value::from("AFFECTED_PATCH_INAPPLICABLE"), xmlrpc::Value::from("AFFECTED_PATCH_APPLICABLE")]);
 
         // check if the systems are affected
         // the CVE can be in multiple errata and thus we should have a map/BT to look up if one CVE has already been requested from the UI
         for cve in cves_resp.as_array().unwrap() {
-            ee.cves.push(cve.as_str().unwrap().to_owned());
-            let cve_audit_resp = Request::new("audit.listSystemsByPatchStatus")
-                                    .arg(suma_clt.session.as_str())
-                                    .arg(cve.as_str())
-                                    .arg(sel_val.clone())
-                                    .call_url(suma_clt.rpcurl.as_str()).unwrap();
-            let numsys = cve_audit_resp.as_array().unwrap().len();
+            let cve_str = cve.as_str().unwrap().to_owned();
+            ee.cves.push(cve_str.to_owned());
+            // cve is only once queried to the SUMA otherwise read from HashMap
+            let syscnt = match cve_systems.get(cve_str.as_str()) {
+                Some(cnt) => cnt.to_owned(),
+                None => cve_syscount(&cve_str, &mut cve_systems, suma_clt)
+            };
             // once the sys_affected is set, we do not revert it, otherwise check if it might have changed
-            if !ee.sys_affected { ee.sys_affected = numsys > 1; }
+            if !ee.sys_affected { ee.sys_affected = syscnt > 1; }
+            
             // insert to database if any system is affected
-            rdbms::store_cve_affsystem(cve.as_str().unwrap(), i32::try_from(numsys).unwrap_or_default()).unwrap();
+            rdbms::store_cve_affsystem(cve.as_str().unwrap(), syscnt).unwrap();
         }
-        // insert errata extended
-        match rdbms::store_cve(&ee) {
+        // insert errstore_eeded
+        match rdbms::store_ee(&ee) {
             Ok(()) => log::info!("CVE successfully stored"),
             Err(e) => log::error!("sumaclient fetch errata error occured {}", e),
         };
     }
+}
+
+// lazy loading method to query the suse manager api and amend the hash map
+fn cve_syscount(i_cve: &str, x_cve_systems: &mut HashMap<String, i32>, suma_clt: &SumaClient) -> i32 {
+    
+    let sel_val = xmlrpc::Value::Array(vec![xmlrpc::Value::from("AFFECTED_PATCH_INAPPLICABLE"), xmlrpc::Value::from("AFFECTED_PATCH_APPLICABLE")]);
+    let cve_audit_resp = Request::new("audit.listSystemsByPatchStatus")
+                                    .arg(suma_clt.session.as_str())
+                                    .arg(i_cve)
+                                    .arg(sel_val.clone())
+                                    .call_url(suma_clt.rpcurl.as_str()).unwrap();
+    let numsys = cve_audit_resp.as_array().unwrap().len();
+    let cnt = i32::try_from(numsys).unwrap_or_default();
+
+    x_cve_systems.insert(i_cve.to_owned(), cnt.to_owned());
+    cnt
 }

--- a/src/suma/sumaclient.rs
+++ b/src/suma/sumaclient.rs
@@ -117,6 +117,7 @@ fn fetch_errata(suma_clt: &SumaClient) {
         let sel_val = xmlrpc::Value::Array(vec![xmlrpc::Value::from("AFFECTED_PATCH_INAPPLICABLE"), xmlrpc::Value::from("AFFECTED_PATCH_APPLICABLE")]);
 
         // check if the systems are affected
+        // the CVE can be in multiple errata and thus we should have a map/BT to look up if one CVE has already been requested from the UI
         for cve in cves_resp.as_array().unwrap() {
             ee.cves.push(cve.as_str().unwrap().to_owned());
             let cve_audit_resp = Request::new("audit.listSystemsByPatchStatus")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,41 +1,6 @@
 #[cfg(test)]
 use cve_audit_types::*;
-use std::collections::BTreeMap;
-use crate::persistence::{keyval, rdbms};
-
-#[test]
-fn kv_demo_data() {
-    // add some code to add demo data
-    let mut errata:Vec<Errata> = Vec::new();
-    // first some errata
-    let mut nr = 1;
-    while nr < 10 {
-        let e = Errata{
-            id: nr 
-           ,date: format!("{}-01-2022", nr)
-           ,update_date: format!("{}-01-2022", nr).to_owned()
-           ,advisory_synopsis: String::from("This is a synopsis which is a longer text")
-           ,advisory_type: String::from("Security")
-           ,advisory_name: format!("advisory-{}", nr).to_owned(),
-        };
-        errata.push(e);
-        nr += 1;
-    }
-    // some CVEs
-    let mut cves: BTreeMap<String, CVE> = BTreeMap::new();
-    let mut nr = 100;
-    while nr < 110 {
-        let c = CVE {
-            cve_id: format!("CVE-2022-{}", nr).to_owned()
-           ,suse_errata_list: errata.clone(),
-        };
-        cves.insert(c.cve_id.clone(), c);
-        nr += 1;
-    }
-    
-    let res = keyval::batch_insert("NEW", cves, None);
-    assert_eq!(res, std::result::Result::Ok(()));
-}
+use crate::persistence::rdbms;
 
 #[test]
 fn sql_demo_data() {
@@ -71,7 +36,7 @@ fn sql_demo_data() {
     for e in errata.iter() {
         let mut ee = ErrataExtended::from(e.to_owned());
         ee.cves = cves.clone();
-        let ok = rdbms::store_cve(&ee);
+        let ok = rdbms::store_ee(&ee);
         assert_eq!(ok, std::result::Result::Ok(()));
     }
 


### PR DESCRIPTION
Improves loading/refreshing of data from [SUSE Manager](https://www.suse.com/de-de/products/suse-manager) API by reducing number of stores to database and implement a lazy cache for CVE-Audits (1:m relation of CVE to SUSE-Errata), since the number of affected systems for one CVE will be always the same for one run.